### PR TITLE
Add container left and top to rectangle SVG x and y for Underline.

### DIFF
--- a/src/marks.js
+++ b/src/marks.js
@@ -183,8 +183,8 @@ export class Underline extends Highlight {
             var r = filtered[i];
 
             var rect = svg.createElement('rect');
-            rect.setAttribute('x', r.left - offset.left);
-            rect.setAttribute('y', r.top - offset.top);
+            rect.setAttribute('x', r.left - offset.left + container.left);
+            rect.setAttribute('y', r.top - offset.top + container.top);
             rect.setAttribute('height', r.height);
             rect.setAttribute('width', r.width);
             rect.setAttribute('fill', 'none');


### PR DESCRIPTION
This fixes the rectangles being shifted in case of Underline:

![image](https://user-images.githubusercontent.com/8367233/30907582-506144fc-a37b-11e7-8a10-682bed72feea.png)
