### PR TITLE
not add a rectangle when calling the `underline` method

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     }
 
     function makeHighlight(range) {
-        var h = pane.addMark(new marks.Highlight(range));
+        var h = pane.addMark(new marks.Underline(range, null, null, {"stroke-width": "1", "stroke": "black", "stroke-linecap": "square"}));
         h.element.addEventListener("click", function () {
             console.log("highlight clicked");
             if (!selecting) { pane.removeMark(h); }

--- a/src/marks.js
+++ b/src/marks.js
@@ -182,25 +182,11 @@ export class Underline extends Highlight {
         for (var i = 0, len = filtered.length; i < len; i++) {
             var r = filtered[i];
 
-            var rect = svg.createElement('rect');
-            rect.setAttribute('x', r.left - offset.left + container.left);
-            rect.setAttribute('y', r.top - offset.top + container.top);
-            rect.setAttribute('height', r.height);
-            rect.setAttribute('width', r.width);
-            rect.setAttribute('fill', 'none');
-
-
             var line = svg.createElement('line');
             line.setAttribute('x1', r.left - offset.left + container.left);
             line.setAttribute('x2', r.left - offset.left + container.left + r.width);
             line.setAttribute('y1', r.top - offset.top + container.top + r.height - 1);
             line.setAttribute('y2', r.top - offset.top + container.top + r.height - 1);
-
-            line.setAttribute('stroke-width', 1);
-            line.setAttribute('stroke', 'black'); //TODO: match text color?
-            line.setAttribute('stroke-linecap', 'square');
-
-            docFrag.appendChild(rect);
 
             docFrag.appendChild(line);
         }


### PR DESCRIPTION
not add a rectangle when calling the `underline` method