### PR TITLE
properly mark sub elements

### DIFF
--- a/src/marks.js
+++ b/src/marks.js
@@ -89,21 +89,15 @@ export class Mark {
     }
 
     filteredRanges() {
-      var rects = Array.from(this.range.getClientRects());
-
-      // De-duplicate the boxes
-      return rects.filter((box) => {
-        for (var i = 0; i < rects.length; i++) {
-          if (rects[i] === box) {
-            return true;
-          }
-          let contained = contains(rects[i], box);
-          if (contained) {
-            return false;
-          }
+        if (!this.range) {
+            return [];
         }
-        return true;
-      })
+
+        // De-duplicate the boxes
+        const rects = Array.from(this.range.getClientRects());
+        const stringRects = rects.map((r) => JSON.stringify(r));
+        const setRects = new Set(stringRects);
+        return Array.from(setRects).map((sr) => JSON.parse(sr));
     }
 
 }


### PR DESCRIPTION
## What's in this PR?

I know this library hasn't been updated in quite a while, but we use epub.js on a client project and were running into this issue where italics and abbreviates weren't being highlighted/underlined when using annotations. (note that we are using a forked version of epub.js that brings this repo into the epub.js repo). This was happening because the current logic for checking if one range contains another was filtering out child elements.

## How to test

Read a book with italics (or inspect the DOM and add an `<em>` tag around some text yourself.
Highlight it.
Does the the sub element get highlighted?