### PR TITLE
Resolved an issue related with Underline

### DIFF
--- a/src/marks.js
+++ b/src/marks.js
@@ -176,14 +176,6 @@ export class Underline extends Highlight {
         for (var i = 0, len = filtered.length; i < len; i++) {
             var r = filtered[i];
 
-            var rect = svg.createElement('rect');
-            rect.setAttribute('x', r.left - offset.left + container.left);
-            rect.setAttribute('y', r.top - offset.top + container.top);
-            rect.setAttribute('height', r.height);
-            rect.setAttribute('width', r.width);
-            rect.setAttribute('fill', 'none');
-
-
             var line = svg.createElement('line');
             line.setAttribute('x1', r.left - offset.left + container.left);
             line.setAttribute('x2', r.left - offset.left + container.left + r.width);
@@ -191,10 +183,7 @@ export class Underline extends Highlight {
             line.setAttribute('y2', r.top - offset.top + container.top + r.height - 1);
 
             line.setAttribute('stroke-width', 1);
-            line.setAttribute('stroke', 'black'); //TODO: match text color?
             line.setAttribute('stroke-linecap', 'square');
-
-            docFrag.appendChild(rect);
 
             docFrag.appendChild(line);
         }


### PR DESCRIPTION
@fchasen I am using epubjs in my react application where I tried to impliment underline feature of epubjs. below are the problems which I was facing:

Unable to set color of underline
After marking as underline, rectangle shape is created like below
![image](https://user-images.githubusercontent.com/15012572/201484436-5967ac83-2643-49b4-9dad-85d64b496e54.png)

After these changes:

Able to pass color of underline by setting below css
.epubjs-ul { stroke: red; stroke-width: 2px; stroke-linecap: square; stroke-opacity: 0.8; }
This solution will support dark mode
Clicking on underline can be resolved by increasing stroke-width

Below are the output:
![image](https://user-images.githubusercontent.com/15012572/201484350-0979dbe2-879b-4c5b-af51-50d2d0400345.png)
